### PR TITLE
feat: per-tool timeout overrides via AGY_TIMEOUT_<TOOL> env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Failovers are annotated in the response footer (`failover: <model>: quota exhaus
 
 ### Timeouts and cancellation
 
-Each tool has its own default timeout sized to its job: `web_lookup` 120s, `deep_search` 180s, `analyze_files` / `adversarial_review` / `follow_up` 300s, `delegate` 600s. Setting `AGY_TIMEOUT` explicitly overrides all of them. The kill path escalates SIGTERM → SIGKILL across the whole process group, and the deadline fires even if agy's helper processes hold the output pipes open. Cancelling the tool call from the MCP client (e.g. pressing Esc in Claude Code) also kills the agy run instead of orphaning it.
+Each tool has its own default timeout sized to its job: `web_lookup` 120s, `deep_search` 180s, `analyze_files` / `adversarial_review` / `follow_up` 300s, `delegate` 600s. Setting `AGY_TIMEOUT` explicitly overrides all of them at once. To change a single tool, set `AGY_TIMEOUT_<TOOL_NAME>` instead (e.g. `AGY_TIMEOUT_DEEP_SEARCH=300`); a per-tool override takes precedence over the global `AGY_TIMEOUT` and the tool's default. The full set of per-tool variables is `AGY_TIMEOUT_ANALYZE_FILES`, `AGY_TIMEOUT_DEEP_SEARCH`, `AGY_TIMEOUT_WEB_LOOKUP`, `AGY_TIMEOUT_ADVERSARIAL_REVIEW`, `AGY_TIMEOUT_FOLLOW_UP`, and `AGY_TIMEOUT_DELEGATE`. The kill path escalates SIGTERM → SIGKILL across the whole process group, and the deadline fires even if agy's helper processes hold the output pipes open. Cancelling the tool call from the MCP client (e.g. pressing Esc in Claude Code) also kills the agy run instead of orphaning it.
 
 ## Configuration
 
@@ -88,7 +88,8 @@ All optional, via environment variables:
 | Variable | Default | Description |
 |---|---|---|
 | `AGY_PATH` | `agy` | Path to the agy binary |
-| `AGY_TIMEOUT` | per-tool | Seconds; overrides the per-tool timeouts (see above), passed as `--print-timeout`, enforced with a 15s kill grace |
+| `AGY_TIMEOUT` | per-tool | Seconds; overrides all per-tool timeouts at once (see above), passed as `--print-timeout`, enforced with a 15s kill grace |
+| `AGY_TIMEOUT_<TOOL>` | per-tool | Seconds; overrides the timeout for a single tool only, e.g. `AGY_TIMEOUT_DEEP_SEARCH=300`. Wins over `AGY_TIMEOUT` |
 | `AGY_MAX_OUTPUT_CHARS` | `50000` | Truncation cap for tool output |
 | `AGY_DEFAULT_MODEL` | unset | Fallback model when no chain entry is available |
 | `AGY_SKIP_PERMISSIONS` | `true` | Pass `--dangerously-skip-permissions` to agy |

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,12 @@ export interface Config {
   timeoutSec: number;
   /** True when AGY_TIMEOUT was set explicitly; overrides per-tool timeouts. */
   timeoutExplicit: boolean;
+  /**
+   * Per-tool timeout overrides from AGY_TIMEOUT_<TOOL_NAME> env vars
+   * (e.g. AGY_TIMEOUT_DEEP_SEARCH), keyed by lowercased tool name.
+   * Takes precedence over the global AGY_TIMEOUT and the tool's default.
+   */
+  perToolTimeouts: Record<string, number>;
   maxOutputChars: number;
   defaultModel: string | undefined;
   skipPermissions: boolean;
@@ -15,11 +21,24 @@ function positiveInt(raw: string | undefined, fallback: number): number {
   return Number.isInteger(n) && n > 0 ? n : fallback;
 }
 
+function loadPerToolTimeouts(env: Record<string, string | undefined>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(env)) {
+    if (!key.startsWith("AGY_TIMEOUT_")) continue;
+    const tool = key.slice("AGY_TIMEOUT_".length).toLowerCase();
+    if (!tool) continue;
+    const n = Number(raw);
+    if (Number.isInteger(n) && n > 0) out[tool] = n;
+  }
+  return out;
+}
+
 export function loadConfig(env: Record<string, string | undefined> = process.env): Config {
   return {
     agyPath: env.AGY_PATH || "agy",
     timeoutSec: positiveInt(env.AGY_TIMEOUT, 1200),
     timeoutExplicit: positiveInt(env.AGY_TIMEOUT, 0) > 0,
+    perToolTimeouts: loadPerToolTimeouts(env),
     maxOutputChars: positiveInt(env.AGY_MAX_OUTPUT_CHARS, 50_000),
     defaultModel: env.AGY_DEFAULT_MODEL || undefined,
     skipPermissions: env.AGY_SKIP_PERMISSIONS !== "false",

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,9 @@ export function createToolHandler(
       const cwd = (args.cwd as string | undefined) ?? process.cwd();
       const conversationId = args.session_id as string | undefined;
       const prompt = tool.buildPrompt(args, cwd);
-      const timeoutSec = cfg.timeoutExplicit ? cfg.timeoutSec : tool.timeoutSec;
+      const timeoutSec =
+        cfg.perToolTimeouts[tool.name] ??
+        (cfg.timeoutExplicit ? cfg.timeoutSec : tool.timeoutSec);
 
       const resolution = conversationId
         ? { models: [undefined], note: undefined }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,6 +8,7 @@ describe("loadConfig", () => {
       agyPath: "agy",
       timeoutSec: 1200,
       timeoutExplicit: false,
+      perToolTimeouts: {},
       maxOutputChars: 50_000,
       defaultModel: undefined,
       skipPermissions: true,
@@ -39,6 +40,16 @@ describe("loadConfig", () => {
     expect(c.timeoutSec).toBe(1200);
     expect(c.timeoutExplicit).toBe(false);
     expect(c.maxOutputChars).toBe(50_000);
+  });
+
+  it("parses per-tool AGY_TIMEOUT_<TOOL> overrides", () => {
+    const c = loadConfig({ AGY_TIMEOUT_DEEP_SEARCH: "300", AGY_TIMEOUT_DELEGATE: "900" });
+    expect(c.perToolTimeouts).toEqual({ deep_search: 300, delegate: 900 });
+  });
+
+  it("ignores non-positive per-tool timeout values", () => {
+    const c = loadConfig({ AGY_TIMEOUT_DEEP_SEARCH: "abc", AGY_TIMEOUT_DELEGATE: "-5" });
+    expect(c.perToolTimeouts).toEqual({});
   });
 
   it("reads AGY_ON_FAILURE=strict", () => {

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -14,6 +14,7 @@ const cfg: Config = {
   agyPath: "agy",
   timeoutSec: 600,
   timeoutExplicit: false,
+  perToolTimeouts: {},
   maxOutputChars: 100,
   defaultModel: undefined,
   skipPermissions: true,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -10,6 +10,7 @@ const cfg: Config = {
   agyPath: "agy",
   timeoutSec: 600,
   timeoutExplicit: false,
+  perToolTimeouts: {},
   maxOutputChars: 50_000,
   defaultModel: undefined,
   skipPermissions: true,
@@ -108,6 +109,24 @@ describe("createToolHandler", () => {
     await handlerFor("web_lookup", f, { timeoutSec: 900, timeoutExplicit: true })({ query: "q" });
     const args = f.runs[0].args;
     expect(args[args.indexOf("--print-timeout") + 1]).toBe("900s");
+  });
+
+  it("per-tool AGY_TIMEOUT_<TOOL> overrides only that tool", async () => {
+    const f = fakeDeps();
+    const cfg = { perToolTimeouts: { deep_search: 300 } };
+    await handlerFor("deep_search", f, cfg)({ query: "q" });
+    expect(f.runs[0].args[f.runs[0].args.indexOf("--print-timeout") + 1]).toBe("300s");
+    // a tool without an override keeps its default
+    await handlerFor("web_lookup", f, cfg)({ query: "q" });
+    const tool = TOOLS.find((t) => t.name === "web_lookup")!;
+    expect(f.runs[1].args[f.runs[1].args.indexOf("--print-timeout") + 1]).toBe(`${tool.timeoutSec}s`);
+  });
+
+  it("per-tool override wins over explicit global AGY_TIMEOUT", async () => {
+    const f = fakeDeps();
+    const cfg = { timeoutSec: 900, timeoutExplicit: true, perToolTimeouts: { deep_search: 300 } };
+    await handlerFor("deep_search", f, cfg)({ query: "q" });
+    expect(f.runs[0].args[f.runs[0].args.indexOf("--print-timeout") + 1]).toBe("300s");
   });
 
   it("fails over to the next chain model on quota exhaustion", async () => {


### PR DESCRIPTION
## Summary

Each tool can now have its timeout configured independently via an `AGY_TIMEOUT_<TOOL_NAME>` env var — without touching the others or republishing the package.

Previously the only knob was the global `AGY_TIMEOUT`, which overrides **every** tool's timeout at once (e.g. raising `deep_search` to 300s would also drop `delegate` from 600s to 300s).

**Precedence:** per-tool env (`AGY_TIMEOUT_DEEP_SEARCH`) > global `AGY_TIMEOUT` > per-tool default.

## Changes

- **config**: parse `AGY_TIMEOUT_<TOOL>` env vars into a `perToolTimeouts` map (keyed by lowercased tool name; ignores non-positive/non-integer values)
- **server**: resolve a per-tool override ahead of the global override and the tool default
- **README**: document the pattern, the precedence, and the full list of variables
- **tests**: env parsing, ignore-invalid values, per-tool-only application, and per-tool-wins-over-global precedence

## Variables

`AGY_TIMEOUT_ANALYZE_FILES`, `AGY_TIMEOUT_DEEP_SEARCH`, `AGY_TIMEOUT_WEB_LOOKUP`, `AGY_TIMEOUT_ADVERSARIAL_REVIEW`, `AGY_TIMEOUT_FOLLOW_UP`, `AGY_TIMEOUT_DELEGATE`

## Verification

- `npm run typecheck` ✅
- `npm test` — 70 passed, 1 skipped (+4 new tests) ✅
- `npm run build` ✅