### PR TITLE
docs: center header, add Glama score badge and directory listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/agy-bridge)](https://www.npmjs.com/package/agy-bridge)
 [![node](https://img.shields.io/node/v/agy-bridge)](https://nodejs.org)
 [![license](https://img.shields.io/npm/l/agy-bridge)](LICENSE)
+
 [![Glama score](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge/badges/score.svg)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
 
 An MCP bridge that lets **Claude Code delegate heavy tasks to the Antigravity CLI (`agy`)** — saving Claude's context window and tokens for what matters.
@@ -14,6 +15,7 @@ An MCP bridge that lets **Claude Code delegate heavy tasks to the Antigravity CL
 Claude sends a task → the bridge routes it to the best available model via `agy` → only the answer comes back. Large files, deep git searches, and web lookups never touch Claude's context.
 
 **Listed on**
+
 [![Glama](https://img.shields.io/badge/Glama-agy--bridge-7c3aed)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
 [![MCP Market](https://img.shields.io/badge/MCP%20Market-agy--bridge-0ea5e9)](https://mcpmarket.com/server/agy-bridge)
 [![PulseMCP](https://img.shields.io/badge/PulseMCP-agy--bridge-f43f5e)](https://www.pulsemcp.com/servers/sshahzaiib-agy-bridge)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # agy-bridge
 
 [![CI](https://github.com/sshahzaiib/agy-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/sshahzaiib/agy-bridge/actions/workflows/ci.yml)
@@ -5,10 +7,20 @@
 [![npm downloads](https://img.shields.io/npm/dm/agy-bridge)](https://www.npmjs.com/package/agy-bridge)
 [![node](https://img.shields.io/node/v/agy-bridge)](https://nodejs.org)
 [![license](https://img.shields.io/npm/l/agy-bridge)](LICENSE)
+[![Glama score](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge/badges/score.svg)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
 
 An MCP bridge that lets **Claude Code delegate heavy tasks to the Antigravity CLI (`agy`)** — saving Claude's context window and tokens for what matters.
 
 Claude sends a task → the bridge routes it to the best available model via `agy` → only the answer comes back. Large files, deep git searches, and web lookups never touch Claude's context.
+
+**Listed on**
+[![Glama](https://img.shields.io/badge/Glama-agy--bridge-7c3aed)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
+[![MCP Market](https://img.shields.io/badge/MCP%20Market-agy--bridge-0ea5e9)](https://mcpmarket.com/server/agy-bridge)
+[![PulseMCP](https://img.shields.io/badge/PulseMCP-agy--bridge-f43f5e)](https://www.pulsemcp.com/servers/sshahzaiib-agy-bridge)
+[![mcp.so](https://img.shields.io/badge/mcp.so-agy--bridge-22c55e)](https://mcp.so/server/agy-bridge/sshahzaiib)
+[![MCP Servers](https://img.shields.io/badge/MCP%20Servers-agy--bridge-f59e0b)](https://mcpservers.org/servers/sshahzaiib/agy-bridge)
+
+</div>
 
 ```
 User → Claude Code → agy-bridge (MCP) → agy CLI → Gemini / Claude / GPT-OSS


### PR DESCRIPTION
Centers the README header block and surfaces the project's directory listings.

## Changes
- Wrapped the title, badges, and tagline in `<div align="center">` (closed before the ASCII flow diagram so that code block stays left-aligned).
- Added the live **Glama score badge** to the main badge row.
- Added a **Listed on** row linking to Glama, MCP Market, PulseMCP, mcp.so, and MCP Servers.
