### PR TITLE
chore: rebrand fork as @bto-labs/agy-bridge v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,20 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/sshahzaiib/agy-bridge/main/assets/banner.svg" alt="agy-bridge — Claude Code delegates heavy tasks to the Antigravity CLI" width="100%">
+<img src="https://raw.githubusercontent.com/bto-labs/agy-bridge/main/assets/banner.svg" alt="agy-bridge — Claude Code delegates heavy tasks to the Antigravity CLI" width="100%">
 
 # agy-bridge
 
-[![CI](https://github.com/sshahzaiib/agy-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/sshahzaiib/agy-bridge/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/agy-bridge)](https://www.npmjs.com/package/agy-bridge)
-[![npm downloads](https://img.shields.io/npm/dm/agy-bridge)](https://www.npmjs.com/package/agy-bridge)
-[![node](https://img.shields.io/node/v/agy-bridge)](https://nodejs.org)
-[![license](https://img.shields.io/npm/l/agy-bridge)](LICENSE)
-
-[![Glama score](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge/badges/score.svg)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
-
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/sshahzaiib-agy-bridge-badge.png)](https://mseep.ai/app/sshahzaiib-agy-bridge)
+[![CI](https://github.com/bto-labs/agy-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/bto-labs/agy-bridge/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@bto-labs/agy-bridge)](https://www.npmjs.com/package/@bto-labs/agy-bridge)
+[![npm downloads](https://img.shields.io/npm/dm/@bto-labs/agy-bridge)](https://www.npmjs.com/package/@bto-labs/agy-bridge)
+[![node](https://img.shields.io/node/v/@bto-labs/agy-bridge)](https://nodejs.org)
+[![license](https://img.shields.io/npm/l/@bto-labs/agy-bridge)](LICENSE)
 
 An MCP bridge that lets **Claude Code delegate heavy tasks to the Antigravity CLI (`agy`)** — saving Claude's context window and tokens for what matters.
 
 Claude sends a task → the bridge routes it to the best available model via `agy` → only the answer comes back. Large files, deep git searches, and web lookups never touch Claude's context.
 
-**Listed on**
-
-[![Glama](https://img.shields.io/badge/Glama-agy--bridge-7c3aed)](https://glama.ai/mcp/servers/sshahzaiib/agy-bridge)
-[![MCP Market](https://img.shields.io/badge/MCP%20Market-agy--bridge-0ea5e9)](https://mcpmarket.com/server/agy-bridge)
-[![PulseMCP](https://img.shields.io/badge/PulseMCP-agy--bridge-f43f5e)](https://www.pulsemcp.com/servers/sshahzaiib-agy-bridge)
-[![mcp.so](https://img.shields.io/badge/mcp.so-agy--bridge-22c55e)](https://mcp.so/server/agy-bridge/sshahzaiib)
-[![MCP Servers](https://img.shields.io/badge/MCP%20Servers-agy--bridge-f59e0b)](https://mcpservers.org/servers/sshahzaiib/agy-bridge)
-[![Verified on MseeP](https://img.shields.io/badge/MseeP.ai-verified-2563eb)](https://mseep.ai/app/2f439062-d211-4a6c-b41b-3a603f490a32)
+Forked and maintained by [BTO Labs](https://github.com/bto-labs) under the MIT license.
 
 </div>
 
@@ -58,10 +47,10 @@ User → Claude Code → agy-bridge (MCP) → agy CLI → Gemini / Claude / GPT-
 #    add-json bakes in a generous client-side timeout so long analyze_files /
 #    delegate calls don't trip Claude Code's tool-call deadline (see Timeouts).
 claude mcp add-json -s user agy-bridge \
-  '{"command":"npx","args":["-y","agy-bridge"],"timeout":600000}'
+  '{"command":"npx","args":["-y","@bto-labs/agy-bridge"],"timeout":600000}'
 
 # 2. Add delegation rules to your project (or ~/.claude/CLAUDE.md for global)
-curl -o CLAUDE.md https://raw.githubusercontent.com/sshahzaiib/agy-bridge/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/bto-labs/agy-bridge/main/CLAUDE.md
 ```
 
 > The `"timeout": 600000` (10 min, milliseconds) is the **client-side** tool-call
@@ -82,7 +71,7 @@ response` while the agy run is still going. If your client doesn't honor a
 | `follow_up`          | Continue a prior session by `session_id` — no context resend    | inherits the session                                              |
 | `delegate`           | Anything else heavy                                             | Gemini 3.5 Flash (High)                                           |
 
-All tools accept optional `cwd` (project root) and `model` (exact name from `agy models`; validated, with available models listed on mismatch).
+All tools accept optional `cwd` (project root) and `model` (exact CLI ID or display name from `agy models`; validated, with available models listed on mismatch).
 
 Every response ends with a footer:
 
@@ -146,13 +135,13 @@ npm run build      # tsup → dist/index.js
 
 Contributions are welcome — open an issue or PR.
 
-<a href="https://github.com/sshahzaiib/agy-bridge/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=sshahzaiib/agy-bridge" alt="Contributors" />
+<a href="https://github.com/bto-labs/agy-bridge/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=bto-labs/agy-bridge" alt="Contributors" />
 </a>
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sshahzaiib/agy-bridge&type=Date)](https://www.star-history.com/#sshahzaiib/agy-bridge&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=bto-labs/agy-bridge&type=Date)](https://www.star-history.com/#bto-labs/agy-bridge&Date)
 
 ## License
 

--- a/docs/multi-client-support.md
+++ b/docs/multi-client-support.md
@@ -8,7 +8,7 @@ Extend agy-bridge beyond Claude Code to other MCP-capable coding agents:
 ## Key insight: zero server changes
 
 agy-bridge speaks standard MCP over stdio — the protocol is client-agnostic,
-and any MCP client can run `npx -y agy-bridge` today. The only "Claude"
+and any MCP client can run `npx -y @bto-labs/agy-bridge` today. The only "Claude"
 reference in `src/` is a backend model name in the `adversarial_review`
 routing chain (`src/tools.ts`), not a client assumption.
 
@@ -48,7 +48,7 @@ Config snippets (verified current as of June 2026):
 **Codex CLI**
 
 ```bash
-codex mcp add agy-bridge --command npx --args -y agy-bridge
+codex mcp add agy-bridge --command npx --args -y @bto-labs/agy-bridge
 ```
 
 or `~/.codex/config.toml` (project scope: `.codex/config.toml`):
@@ -56,13 +56,13 @@ or `~/.codex/config.toml` (project scope: `.codex/config.toml`):
 ```toml
 [mcp_servers.agy-bridge]
 command = "npx"
-args = ["-y", "agy-bridge"]
+args = ["-y", "@bto-labs/agy-bridge"]
 ```
 
 **Cursor** — `~/.cursor/mcp.json` (project scope: `.cursor/mcp.json`):
 
 ```json
-{ "mcpServers": { "agy-bridge": { "command": "npx", "args": ["-y", "agy-bridge"] } } }
+{ "mcpServers": { "agy-bridge": { "command": "npx", "args": ["-y", "@bto-labs/agy-bridge"] } } }
 ```
 
 **Windsurf** — `~/.codeium/windsurf/mcp_config.json`: same JSON shape as Cursor.

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["sshahzaiib"]
+  "maintainers": ["bto-labs"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "agy-bridge",
-  "version": "0.4.1",
+  "name": "@bto-labs/agy-bridge",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agy-bridge",
-      "version": "0.4.1",
+      "name": "@bto-labs/agy-bridge",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "agy-bridge",
-  "version": "0.4.1",
+  "name": "@bto-labs/agy-bridge",
+  "version": "0.5.0",
   "description": "MCP bridge that lets Claude Code delegate heavy tasks to the Antigravity CLI (agy) — purpose-built tools, model routing with fallback, and multi-turn session continuity.",
-  "mcpName": "io.github.sshahzaiib/agy-bridge",
+  "mcpName": "io.github.bto-labs.agy-bridge",
   "type": "module",
   "bin": {
     "agy-bridge": "dist/index.js"
@@ -14,6 +14,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18"
   },
@@ -34,10 +37,17 @@
     "delegation"
   ],
   "author": "Shahzaib (https://github.com/sshahzaiib)",
+  "contributors": [
+    "BTO Labs (https://github.com/bto-labs)"
+  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sshahzaiib/agy-bridge.git"
+    "url": "git+https://github.com/bto-labs/agy-bridge.git"
   },
+  "bugs": {
+    "url": "https://github.com/bto-labs/agy-bridge/issues"
+  },
+  "homepage": "https://github.com/bto-labs/agy-bridge#readme",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,8 +1,26 @@
+const MODEL_NAME_RE = /^(Gemini|Claude|GPT)[- ]/i;
+
+function looksLikeModelName(line: string): boolean {
+  return MODEL_NAME_RE.test(line);
+}
+
 export function parseModels(output: string): string[] {
-  return output
-    .split("\n")
-    .map((l) => l.trim().replace(/\s*\(current\)$/, ""))
-    .filter((l) => l.length > 0);
+  const models = new Set<string>();
+  for (const raw of output.split("\n")) {
+    const line = raw.trim().replace(/\s*\(current\)$/, "");
+    if (line.length === 0) continue;
+
+    if (line.includes("\t")) {
+      const [rawId, rawDisplay] = line.split("\t", 2);
+      const cliId = rawId?.trim() ?? "";
+      const displayName = rawDisplay?.trim() ?? "";
+      if (cliId && looksLikeModelName(cliId)) models.add(cliId);
+      if (displayName && looksLikeModelName(displayName)) models.add(displayName);
+    } else if (looksLikeModelName(line)) {
+      models.add(line);
+    }
+  }
+  return [...models];
 }
 
 export interface ResolveOptions {

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,7 +118,7 @@ export function createServer(): McpServer {
   });
   const cooldowns = new CooldownRegistry();
 
-  const server = new McpServer({ name: "agy-bridge", version: "0.4.0" });
+  const server = new McpServer({ name: "agy-bridge", version: "0.5.0" });
   for (const tool of TOOLS) {
     server.registerTool(
       tool.name,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -20,7 +20,7 @@ const commonShape = {
     .string()
     .optional()
     .describe(
-      'Override the model (exact name from `agy models`, e.g. "Gemini 3.1 Pro (High)"). ' +
+      'Override the model (CLI ID or display name from `agy models`, e.g. "gemini-3.1-pro-high" or "Gemini 3.1 Pro (High)"). ' +
         "Normally omit — the tool routes automatically.",
     ),
 };

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -6,6 +6,12 @@ Gemini 3.5 Flash (High)
 Gemini 3.1 Pro (High)
 `;
 
+// agy 1.1.12+ prints `cli-id<TAB>Display Name` and a leading status line.
+const LISTING_V2 = `Fetching available models...
+gemini-3.6-flash-high	Gemini 3.6 Flash (High)
+gemini-3.1-pro-high	Gemini 3.1 Pro (High)
+`;
+
 describe("parseModels", () => {
   it("returns one trimmed model per non-empty line", () => {
     expect(parseModels(LISTING)).toEqual([
@@ -20,6 +26,22 @@ describe("parseModels", () => {
       "Claude Opus 4.6 (Thinking)",
     ]);
   });
+
+  it("parses two-column agy output with a leading status line", () => {
+    expect(parseModels(LISTING_V2)).toEqual([
+      "gemini-3.6-flash-high",
+      "Gemini 3.6 Flash (High)",
+      "gemini-3.1-pro-high",
+      "Gemini 3.1 Pro (High)",
+    ]);
+  });
+
+  it("strips ' (current)' from the display column", () => {
+    expect(parseModels("gemini-3.1-pro-high\tGemini 3.1 Pro (High) (current)\n")).toEqual([
+      "gemini-3.1-pro-high",
+      "Gemini 3.1 Pro (High)",
+    ]);
+  });
 });
 
 describe("ModelRegistry.resolve", () => {
@@ -31,6 +53,16 @@ describe("ModelRegistry.resolve", () => {
 
   it("uses explicit model when available", async () => {
     const r = await registry(LISTING).resolve({ explicit: "Gemini 3.1 Pro (High)", chain: [] });
+    expect(r.model).toBe("Gemini 3.1 Pro (High)");
+  });
+
+  it("accepts a CLI ID as explicit model", async () => {
+    const r = await registry(LISTING_V2).resolve({ explicit: "gemini-3.1-pro-high", chain: [] });
+    expect(r.model).toBe("gemini-3.1-pro-high");
+  });
+
+  it("accepts a display name as explicit model with two-column output", async () => {
+    const r = await registry(LISTING_V2).resolve({ explicit: "Gemini 3.1 Pro (High)", chain: [] });
     expect(r.model).toBe("Gemini 3.1 Pro (High)");
   });
 


### PR DESCRIPTION
## Summary
- Rename package to `@bto-labs/agy-bridge` and add `publishConfig.access: "public"`
- Update repository, docs, and MCP metadata to `bto-labs`
- Fix `parseModels` for `agy` 1.1.12 tab-separated `cli-id\tDisplay Name` output
- Accept both CLI IDs (e.g. `gemini-3.1-pro-high`) and display names

## Test plan
- [x] `npm test` passes (74 passed, 1 skipped)
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Live `runAgy` call with `gemini-3.1-pro-high` succeeded